### PR TITLE
Dynamic gcp secrets

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -1,10 +1,11 @@
 package lib
 
 import (
-	"github.com/3lvia/hn-config-lib-go/hid"
-	"github.com/3lvia/hn-config-lib-go/vault"
 	"log"
 	"net/http"
+
+	"github.com/3lvia/hn-config-lib-go/hid"
+	"github.com/3lvia/hn-config-lib-go/vault"
 )
 
 // Example executes examples of the three core usecases of this package.

--- a/example_test.go
+++ b/example_test.go
@@ -18,7 +18,7 @@ func Example() {
 
 // vaultExample represents the simplest way to get a secret from Vault.
 // Requires, at a minimum, that env vars VAULT_ADDR and either GITHUB_TOKEN or the K8 related ones are set. See readme for more information.
-func vaultExample() *vault.Secret {
+func vaultExample() vault.Secret {
 	// Make reusable vault item
 	myVault, err := vault.New()
 	if err != nil {
@@ -37,7 +37,7 @@ func vaultExample() *vault.Secret {
 
 // hidClientExample represents the client side of a request with HID authorization. User and secret for HID.GetToken may be from a wide variety of sources.
 // Requires, at a minimum, that env var HID_ADDR is set.
-func hidClientExample(mySecret *vault.Secret) *http.Request {
+func hidClientExample(mySecret vault.Secret) *http.Request {
 	// Make reusable HID item
 	myHID, err := hid.New()
 	if err != nil {
@@ -45,7 +45,7 @@ func hidClientExample(mySecret *vault.Secret) *http.Request {
 	}
 
 	// Get a bearer token from HID
-	myToken, err := myHID.GetToken("username", mySecret.Data["key"])
+	myToken, err := myHID.GetToken("username", mySecret.GetData()["key"].(string))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/gcpCreds/main.go
+++ b/examples/gcpCreds/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/3lvia/hn-config-lib-go/vault"
+)
+
+func main() {
+	myVault, err := vault.New()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Get a secret from the vault
+	err = myVault.SetupAndRenewGcpCredentials("monitoring", "super", 300)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for {
+		fmt.Println(time.Now())
+		time.Sleep(60 * time.Second)
+		// for i := 1; i < 60; i++ {
+		// 	time.Sleep(60 * time.Second)
+		// 	fmt.Print(".")
+		// }
+	}
+}

--- a/vault/dynamicSecrets_test.go
+++ b/vault/dynamicSecrets_test.go
@@ -38,7 +38,6 @@ func Test_singleSecretMaintainer_start_notRenewable_returnsAtOnce(t *testing.T) 
 	}
 }
 
-
 func Test_singleSecretMaintainer_start_renewable_iteratesAsExpected(t *testing.T) {
 	// Arrange
 	s1 := &secret{
@@ -123,6 +122,10 @@ func (m *mockSecretGetter) GetSecret(path string) (Secret, error) {
 }
 
 func (m *mockSecretGetter) SetDefaultGoogleCredentials(path, key string) error {
+	return nil
+}
+
+func (m *mockSecretGetter) SetupAndRenewGcpCredentials(system string, roleset string, ttl int) error {
 	return nil
 }
 

--- a/vault/googleCredentialsRenewer.go
+++ b/vault/googleCredentialsRenewer.go
@@ -1,0 +1,102 @@
+package vault
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+type rolesets struct {
+	Data map[string][]string `json:"data"`
+}
+
+type gcpCredentials struct {
+	LeaseDuration int                `json:"lease_duration"`
+	Data          gcpCredentialsData `json:"data"`
+}
+
+type gcpCredentialsData struct {
+	PrivateKeyData string `json:"private_key_data"`
+}
+
+func (vault *Vault) SetupAndRenewGcpCredentials(system string, roleset string, ttl int) error {
+	err := validateRoleset(vault, system, roleset)
+	if err != nil {
+		return err
+	}
+
+	// fmt.Printf("PrivateKeyData %s\n", gcpCredentials.Data.PrivateKeyData)
+	leaseDuration, err := SetupGcpCredentials(vault, system, roleset, ttl)
+	if err != nil {
+		return err
+	}
+
+	renewTime := time.Now().Add(time.Duration(leaseDuration) * time.Second)
+	// fmt.Printf("renewTime: %s", renewTime)
+
+	go func() {
+		for range time.Tick(time.Second * 1) {
+			// fmt.Println("Ticking every 1 seconds")
+			if time.Now().Add(60 * time.Second).After(renewTime) {
+				leaseDuration, _ = SetupGcpCredentials(vault, system, roleset, ttl)
+				renewTime = time.Now().Add(time.Duration(leaseDuration) * time.Second)
+				// fmt.Printf("renewTime: %s", renewTime)
+			}
+		}
+	}()
+	return nil
+}
+
+func SetupGcpCredentials(vault *Vault, system string, roleset string, ttl int) (int, error) {
+	url := makeURL(vault.Config.Addr, fmt.Sprintf("%s/gcp/key/%s", system, roleset))
+	// fmt.Printf("url %s\n", url)
+
+	var jsonStr = []byte(fmt.Sprintf(`{"ttl":"%d"}`, ttl))
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonStr))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Vault-Token", vault.Token.Auth.ClientToken)
+
+	if err != nil {
+		return 0, err
+	}
+
+	gcpCredentials := new(gcpCredentials)
+	if err = vault.do(req, &gcpCredentials); err != nil {
+		return 0, errors.Wrap(err, fmt.Sprintf("while getting gcpCredentials from Vault. system: %s url: %s", system, url))
+	}
+	// fmt.Printf("LeaseDuration %d\n", gcpCredentials.LeaseDuration)
+
+	credsFilename := fmt.Sprintf("%s/go-creds.json", os.TempDir())
+	err = ioutil.WriteFile(credsFilename, []byte(gcpCredentials.Data.PrivateKeyData), 0600)
+
+	os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", credsFilename)
+	fmt.Println("GOOGLE_APPLICATION_CREDENTIALS environment variable set")
+	// fmt.Printf("PrivateKeyData %s\n", gcpCredentials.Data.PrivateKeyData[500:509])
+	return gcpCredentials.LeaseDuration, nil
+}
+
+func validateRoleset(vault *Vault, system string, roleset string) error {
+	url := makeURL(vault.Config.Addr, fmt.Sprintf("%s/gcp/rolesets?list=true", system))
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("X-Vault-Token", vault.Token.Auth.ClientToken)
+
+	rolesets := new(rolesets)
+	if err = vault.do(req, &rolesets); err != nil {
+		return errors.Wrap(err, fmt.Sprintf("while getting rolesets from Vault. system: %s url: %s", system, url))
+	}
+	for _, a := range rolesets.Data["keys"] {
+		if a == roleset {
+			return nil
+		}
+	}
+	return fmt.Errorf("Roleset '%s' does not exist for the system '%s'. Rolesets: %s", roleset, system, rolesets.Data["keys"])
+}

--- a/vault/googleCredentialsRenewer.go
+++ b/vault/googleCredentialsRenewer.go
@@ -24,6 +24,10 @@ type gcpCredentialsData struct {
 	PrivateKeyData string `json:"private_key_data"`
 }
 
+// SetupAndRenewGcpCredentials uses Vault to create a dynamic secret and sets the
+// environment variable GOOGLE_APPLICATION_CREDENTIALS which all gcp client libraries use.
+// The system and roleset determines what gcp resource you can access
+// The gcp roleset must be set up in terraform using the module terraform-vault-gcp_secret_roleset
 func (vault *Vault) SetupAndRenewGcpCredentials(system string, roleset string, ttl int) error {
 	err := validateRoleset(vault, system, roleset)
 	if err != nil {

--- a/vault/secret.go
+++ b/vault/secret.go
@@ -2,7 +2,9 @@ package vault
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
+	"os"
 
 	"github.com/pkg/errors"
 )
@@ -117,3 +119,64 @@ func (vault Vault) do2(req *http.Request, dst interface{}) error {
 func (vault Vault) do(req *http.Request, dst interface{}) error {
 	return vault.Client.Do(req, &dst)
 }
+
+type rolesets struct {
+	Data map[string][]string `json:"data"`
+}
+
+type gcpCredentials struct {
+	LeaseDuration int                `json:"lease_duration"`
+	Data          gcpCredentialsData `json:"data"`
+}
+
+type gcpCredentialsData struct {
+	PrivateKeyData string `json:"private_key_data"`
+}
+
+// GetSecret returns the secret from the provided path.
+// In case of 403 response from server, the credentials will be renewed and the request retried once.
+func (vault *Vault) SetupAndRenewGcpCredentials(system string, roleset string, ttl int) error {
+	err := validateRoleset(vault, system)
+	if err != nil {
+		return err
+	}
+
+	url := makeURL(vault.Config.Addr, fmt.Sprintf("%s/gcp/key/%s", system, roleset))
+	fmt.Printf("url %s\n", url)
+
+	req, err := secretsReq(url, vault.Token.Auth.ClientToken)
+	if err != nil {
+		return err
+	}
+
+	gcpCredentials := new(gcpCredentials)
+	if err = vault.do(req, &gcpCredentials); err != nil {
+		return errors.Wrap(err, fmt.Sprintf("while getting gcpCredentials from Vault. system: %s url: %s", system, url))
+	}
+	fmt.Printf("LeaseDuration %d\n", gcpCredentials.LeaseDuration)
+	// fmt.Printf("PrivateKeyData %s\n", gcpCredentials.Data.PrivateKeyData)
+
+	credsFilename := fmt.Sprintf("%s/go-creds.json", os.TempDir())
+	err = ioutil.WriteFile(credsFilename, []byte(gcpCredentials.Data.PrivateKeyData), 0600)
+
+	os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", credsFilename)
+	return nil
+}
+
+func validateRoleset(vault *Vault, system string) error {
+	url := makeURL(vault.Config.Addr, fmt.Sprintf("%s/gcp/rolesets?list=true", system))
+
+	req, err := secretsReq(url, vault.Token.Auth.ClientToken)
+	if err != nil {
+		return err
+	}
+
+	rolesets := new(rolesets)
+	if err = vault.do(req, &rolesets); err != nil {
+		return errors.Wrap(err, fmt.Sprintf("while getting rolesets from Vault. system: %s url: %s", system, url))
+	}
+	fmt.Printf("Rolesets %s\n", rolesets.Data["keys"])
+	return nil
+}
+
+//{"request_id":"2bf836c8-ead6-cf57-b4c5-21644a0351a1","lease_id":"","renewable":false,"lease_duration":0,"data":{"keys":["storage_admin"]},"wrap_info":null,"warnings":null,"auth":null}

--- a/vault/secret_test.go
+++ b/vault/secret_test.go
@@ -111,4 +111,4 @@ func Test_deserializeFromJSON(t *testing.T) {
 	}
 }
 
-const secretResponse string  = `{"request_id":"464ac0ff-fa12-13ca-9e6d-ca3be05ac802","lease_id":"","renewable":false,"lease_duration":0,"data":{"data":{"service-account-key":"my-secret-key"},"metadata":{"created_time":"2020-06-02T08:26:38.487373863Z","deletion_time":"","destroyed":false,"version":1}},"wrap_info":null,"warnings":null,"auth":null}`
+const secretResponse string = `{"request_id":"464ac0ff-fa12-13ca-9e6d-ca3be05ac802","lease_id":"","renewable":false,"lease_duration":0,"data":{"data":{"service-account-key":"my-secret-key"},"metadata":{"created_time":"2020-06-02T08:26:38.487373863Z","deletion_time":"","destroyed":false,"version":1}},"wrap_info":null,"warnings":null,"auth":null}`

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -11,6 +11,7 @@ import (
 type SecretsManager interface {
 	GetSecret(path string) (Secret, error)
 	SetDefaultGoogleCredentials(path, key string) error
+	SetupAndRenewGcpCredentials(system string, roleset string, ttl int) error
 }
 
 // Vault contains all information needed to get and interact with Vault secrets, after initial configuration.

--- a/vault/vault_test.go
+++ b/vault/vault_test.go
@@ -1,9 +1,11 @@
 package vault
 
 import (
+	"io/ioutil"
 	"log"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/3lvia/hn-config-lib-go/env"
 	"github.com/3lvia/hn-config-lib-go/testing/assert"
@@ -58,16 +60,37 @@ func Test_New(t *testing.T) {
 	err = env.Reset()
 	assert.NoErr(t, err)
 }
-
-func Test_New_SetupAndRenewGcpCredentials(t *testing.T) {
-	// Make reusable vault item
+func Test_GetSecret(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
 	myVault, err := New()
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	// Get a secret from the vault
-	err = myVault.SetupAndRenewGcpCredentials("monitoring", "storage_admin", 60)
+	mySecret, err := myVault.GetSecret("libraries/kv/data/manual/integrationtest")
+	if err != nil {
+		log.Fatal(err)
+	}
+	data := mySecret.GetData()["mykey"].(string)
+	if len(data) == 0 {
+		t.Errorf("len(creds) == 0")
+	}
+}
+
+func Test_SetupAndRenewGcpCredentials(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	myVault, err := New()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Get a secret from the vault
+	err = myVault.SetupAndRenewGcpCredentials("monitoring", "storage_admin", 5)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -75,5 +98,43 @@ func Test_New_SetupAndRenewGcpCredentials(t *testing.T) {
 	creds := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")
 	if len(creds) == 0 {
 		t.Errorf("len(creds) == 0")
+	}
+}
+
+func Test_SetupAndRenewGcpCredentials_VerifyRenewing(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	myVault, err := New()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = myVault.SetupAndRenewGcpCredentials("monitoring", "storage_admin", 1)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	creds1, err := ioutil.ReadFile(os.Getenv("GOOGLE_APPLICATION_CREDENTIALS"))
+	// fmt.Printf("creds1: %s\n", creds1[500:509])
+	if err != nil {
+		log.Fatal(err)
+	}
+	if len(creds1) == 0 {
+		t.Errorf("len(creds1) == 0")
+	}
+
+	time.Sleep(5 * time.Second)
+
+	creds2, err := ioutil.ReadFile(os.Getenv("GOOGLE_APPLICATION_CREDENTIALS"))
+	// fmt.Printf("creds2: %s\n", creds2[500:509])
+	if err != nil {
+		log.Fatal(err)
+	}
+	if len(creds2) == 0 {
+		t.Errorf("len(creds1) == 0")
+	}
+	if string(creds1) == string(creds2) {
+		t.Errorf("creds1 == creds2 after renewing")
 	}
 }

--- a/vault/vault_test.go
+++ b/vault/vault_test.go
@@ -1,6 +1,8 @@
 package vault
 
 import (
+	"log"
+	"os"
 	"testing"
 
 	"github.com/3lvia/hn-config-lib-go/env"
@@ -55,4 +57,23 @@ func Test_New(t *testing.T) {
 
 	err = env.Reset()
 	assert.NoErr(t, err)
+}
+
+func Test_New_SetupAndRenewGcpCredentials(t *testing.T) {
+	// Make reusable vault item
+	myVault, err := New()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Get a secret from the vault
+	err = myVault.SetupAndRenewGcpCredentials("monitoring", "storage_admin", 60)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	creds := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")
+	if len(creds) == 0 {
+		t.Errorf("len(creds) == 0")
+	}
 }


### PR DESCRIPTION
Add new public function `Vault.SetupAndRenewGcpCredentials `for setting up dynamic gcp credentials from Vault. This function also renews the credentials before they run out. Sets the environment variable GOOGLE_APPLICATION_CREDENTIALS which are used by all client libraries when accessing GCP resources. 