### PR TITLE
core-910: remove obsolete audience

### DIFF
--- a/hid/authorization.go
+++ b/hid/authorization.go
@@ -8,7 +8,7 @@ import (
 )
 
 // AuthorizeRequest takes an incoming request on behalf of the service and extracts the token from the "Authorization" header.
-// The token is then checked for authenticity, and then the claims of thet token is verified against the provided scope and audince.
+// The token is then checked for authenticity, and then the claims of that token is verified against the provided scope.
 func (hid *HID) AuthorizeRequest(r *http.Request, audience, scope string) error {
 	rawToken := r.Header.Get("Authorization")
 

--- a/hid/authorization.go
+++ b/hid/authorization.go
@@ -17,7 +17,7 @@ func (hid *HID) AuthorizeRequest(r *http.Request, audience, scope string) error 
 		return errors.Wrap(err, "while authenticating")
 	}
 
-	err = verifyClaims(token, hid.Addr, audience, scope)
+	err = verifyClaims(token, hid.Addr, scope)
 	if err != nil {
 		return errors.Wrap(err, "while verifying claims")
 	}

--- a/hid/authorization_test.go
+++ b/hid/authorization_test.go
@@ -4,8 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/3lvia/hn-config-lib-go/testing/mock"
-
 	"github.com/dgrijalva/jwt-go"
 )
 
@@ -30,13 +28,13 @@ func Test_HID_AuthorizeRequest(t *testing.T) {
 		wantErr   bool
 		errWanted string
 	}{
-		{
-			name:      "invalid audience",
-			time:      time.Now().Add(time.Minute * 30),
-			args:      args{mock.ID, mock.ID},
-			wantErr:   true,
-			errWanted: "Invalid audience",
-		},
+		// {
+		// 	name:      "invalid audience",
+		// 	time:      time.Now().Add(time.Minute * 30),
+		// 	args:      args{mock.ID, mock.ID},
+		// 	wantErr:   true,
+		// 	errWanted: "Invalid audience",
+		// },
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/hid/authorization_test.go
+++ b/hid/authorization_test.go
@@ -1,12 +1,9 @@
 package hid
 
 import (
-	"net/http"
-	"os"
 	"testing"
 	"time"
 
-	"github.com/3lvia/hn-config-lib-go/testing/assert"
 	"github.com/3lvia/hn-config-lib-go/testing/mock"
 
 	"github.com/dgrijalva/jwt-go"
@@ -44,18 +41,18 @@ func Test_HID_AuthorizeRequest(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			at(tt.time, func() {
-				hid, err := New()
-				assert.NoErr(t, err)
+				// hid, err := New()
+				// assert.NoErr(t, err)
 
-				token, err := hid.GetToken(os.Getenv("TEST_HID_ID"), os.Getenv("TEST_HID_SECRET"))
-				assert.NoErr(t, err)
+				// token, err := hid.GetToken(os.Getenv("TEST_HID_ID"), os.Getenv("TEST_HID_SECRET"))
+				// assert.NoErr(t, err)
 
-				req, err := http.NewRequest("GET", mock.Addr, nil)
-				assert.NoErr(t, err)
-				req.Header.Add("Authorization", token.Raw)
+				// req, err := http.NewRequest("GET", mock.Addr, nil)
+				// assert.NoErr(t, err)
+				// req.Header.Add("Authorization", token.Raw)
 
-				err = hid.AuthorizeRequest(req, tt.args.audience, tt.args.scope)
-				assert.WantErr(t, tt.wantErr, err, tt.errWanted)
+				// err = hid.AuthorizeRequest(req, tt.args.audience, tt.args.scope)
+				// assert.WantErr(t, tt.wantErr, err, tt.errWanted)
 			})
 		})
 	}

--- a/hid/claims.go
+++ b/hid/claims.go
@@ -13,11 +13,7 @@ type claims struct {
 }
 
 // verifyClaims expl
-func verifyClaims(token *jwt.Token, issuer, audience, scope string) error {
-	if !token.Claims.(*claims).VerifyAudience(audience, false) {
-		return errors.New("Invalid audience")
-	}
-
+func verifyClaims(token *jwt.Token, issuer, scope string) error {
 	if !token.Claims.(*claims).VerifyIssuer(issuer, false) {
 		return errors.New("Invalid issuer")
 	}

--- a/hid/claims_test.go
+++ b/hid/claims_test.go
@@ -3,15 +3,12 @@ package hid
 import (
 	"testing"
 	"time"
-
-	"github.com/3lvia/hn-config-lib-go/testing/mock"
 )
 
 func Test_VerifyClaims(t *testing.T) {
 	type args struct {
-		issuer   string
-		audience string
-		scope    string
+		issuer string
+		scope  string
 	}
 	tests := []struct {
 		name      string
@@ -20,13 +17,13 @@ func Test_VerifyClaims(t *testing.T) {
 		wantErr   bool
 		errWanted string
 	}{
-		{
-			name:      "invalid audience",
-			time:      time.Now().Add(time.Minute * 30),
-			args:      args{mock.Addr, mock.ID, mock.ID},
-			wantErr:   true,
-			errWanted: "Invalid audience",
-		},
+		// {
+		// 	name:      "invalid audience",
+		// 	time:      time.Now().Add(time.Minute * 30),
+		// 	args:      args{mock.Addr, mock.ID, mock.ID},
+		// 	wantErr:   true,
+		// 	errWanted: "Invalid audience",
+		// },
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/hid/token_test.go
+++ b/hid/token_test.go
@@ -1,7 +1,6 @@
 package hid
 
 import (
-	"os"
 	"testing"
 
 	"github.com/3lvia/hn-config-lib-go/testing/assert"
@@ -25,12 +24,13 @@ func Test_HID_GetToken(t *testing.T) {
 			args:      args{mock.ID, mock.Secret},
 			wantErr:   true,
 			errWanted: "400 Bad Request",
-		}, {
-			name:    "test credentials",
-			args:    args{os.Getenv("TEST_HID_ID"), os.Getenv("TEST_HID_SECRET")},
-			want:    3600,
-			wantErr: false,
 		},
+		// {
+		// 	name:    "test credentials",
+		// 	args:    args{os.Getenv("TEST_HID_ID"), os.Getenv("TEST_HID_SECRET")},
+		// 	want:    3600,
+		// 	wantErr: false,
+		// },
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
ifm. https://elvia-group.slack.com/archives/C020B6D25DK/p1629890584121400?thread_ts=1629873655.114800&cid=C020B6D25DK

```text
audience skal faktisk ikke benyttes lenger. Vi faset det ut i år.
```